### PR TITLE
Go tag commas

### DIFF
--- a/internal/generator/go/ast-reader.go
+++ b/internal/generator/go/ast-reader.go
@@ -27,6 +27,7 @@ import (
 	"log"
 	"path"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -666,7 +667,7 @@ func parseAnnotations(tags string, annotations *map[string]*binding.Annotation) 
 	}
 
 	// tags are space-separated
-	for _, tag := range strings.Split(tags, " ") {
+	for _, tag := range regexp.MustCompile("[ ,]+").Split(tags, -1) {
 		if len(tag) > 0 {
 			var name string
 			var value = &binding.Annotation{}

--- a/internal/generator/go/ast-reader.go
+++ b/internal/generator/go/ast-reader.go
@@ -666,7 +666,7 @@ func parseAnnotations(tags string, annotations *map[string]*binding.Annotation) 
 		return nil
 	}
 
-	// tags are space-separated
+	// tags are space or comma separated
 	for _, tag := range regexp.MustCompile("[ ,]+").Split(tags, -1) {
 		if len(tag) > 0 {
 			var name string

--- a/test/comparison/test-all.go
+++ b/test/comparison/test-all.go
@@ -106,15 +106,15 @@ func generateOneDir(t *testing.T, overwriteExpected bool, conf testSpec, srcType
 		errorTransformer = errTrans
 	}
 
-	// Go generator updates generator go.mod when loading files (adds the missing objectbox-go import).
-	// Therefore, we'll load files from the temp dir instead
-	srcDir = genDir
-
 	modelInfoFile := generator.ModelInfoFile(genDir)
 	modelInfoExpectedFile := generator.ModelInfoFile(srcDir) + ".expected"
 
 	modelCodeFile := conf.generator.ModelFile(modelInfoFile, generator.Options{OutPath: genDir})
 	modelCodeExpectedFile := conf.generator.ModelFile(generator.ModelInfoFile(expDir), generator.Options{}) + ".expected"
+
+	// Go generator updates generator go.mod when loading files (adds the missing objectbox-go import).
+	// Therefore, we'll load files from the temp dir instead
+	srcDir = genDir
 
 	// run the generation twice, first time with deleting old modelInfo
 	for i := 0; i <= 1; i++ {

--- a/test/comparison/testdata/go/typeful/objectbox-model.go.expected
+++ b/test/comparison/testdata/go/typeful/objectbox-model.go.expected
@@ -16,6 +16,7 @@ func ObjectBoxModel() *objectbox.Model {
 	model.RegisterBinding(NillableBinding)
 	model.RegisterBinding(TypefulBinding)
 	model.LastEntityId(3, 959367522974354090)
+	model.LastIndexId(2, 8902041070398994519)
 
 	return model
 }

--- a/test/comparison/testdata/go/typeful/objectbox-model.json.expected
+++ b/test/comparison/testdata/go/typeful/objectbox-model.json.expected
@@ -167,7 +167,7 @@
     },
     {
       "id": "3:959367522974354090",
-      "lastPropertyId": "22:3959279844101328186",
+      "lastPropertyId": "22:303089054982227392",
       "name": "Typeful",
       "properties": [
         {
@@ -275,15 +275,19 @@
         {
           "id": "20:388440063886460141",
           "name": "Date",
-          "type": 10
+          "indexId": "1:7561811714888168464",
+          "type": 10,
+          "flags": 8
         },
         {
-          "id": "21:7561811714888168464",
+          "id": "21:3959279844101328186",
           "name": "Time",
-          "type": 10
+          "indexId": "2:8902041070398994519",
+          "type": 10,
+          "flags": 8
         },
         {
-          "id": "22:3959279844101328186",
+          "id": "22:303089054982227392",
           "name": "Time2",
           "type": 10
         }
@@ -291,7 +295,7 @@
     }
   ],
   "lastEntityId": "3:959367522974354090",
-  "lastIndexId": "",
+  "lastIndexId": "2:8902041070398994519",
   "lastRelationId": "",
   "modelVersion": 5,
   "modelVersionParserMinimum": 5,

--- a/test/comparison/testdata/go/typeful/typeful.go
+++ b/test/comparison/testdata/go/typeful/typeful.go
@@ -23,7 +23,7 @@ type Typeful struct {
 	Rune         rune
 	Float32      float32
 	Float64      float64
-	Date         int64     `objectbox:"date"`
-	Time         time.Time `objectbox:"date"`
+	Date         int64     `objectbox:"date index"`
+	Time         time.Time `objectbox:"date,index"`
 	Time2        time.Time // prints a warning, otherwise the same as with an annotation
 }

--- a/test/comparison/testdata/go/typeful/typeful.obx.go.expected
+++ b/test/comparison/testdata/go/typeful/typeful.obx.go.expected
@@ -216,9 +216,13 @@ func (typeful_EntityInfo) AddToModel(model *objectbox.Model) {
 	model.Property("Float32", 7, 18, 4345851588384648695)
 	model.Property("Float64", 8, 19, 7699391924090763411)
 	model.Property("Date", 10, 20, 388440063886460141)
-	model.Property("Time", 10, 21, 7561811714888168464)
-	model.Property("Time2", 10, 22, 3959279844101328186)
-	model.EntityLastPropertyId(22, 3959279844101328186)
+	model.PropertyFlags(8)
+	model.PropertyIndex(1, 7561811714888168464)
+	model.Property("Time", 10, 21, 3959279844101328186)
+	model.PropertyFlags(8)
+	model.PropertyIndex(2, 8902041070398994519)
+	model.Property("Time2", 10, 22, 303089054982227392)
+	model.EntityLastPropertyId(22, 303089054982227392)
 }
 
 // GetId is called by ObjectBox during Put operations to check for existing ID on an object


### PR DESCRIPTION
Fixes https://github.com/objectbox/objectbox-go/issues/24

* adds support for comma as a separator in Go annotations
* minor dev-only comparison test fix ("-update" wasn't updating model.json.expected)


