### PR TITLE
C++ move _OBX_MetaInfo

### DIFF
--- a/internal/generator/c/templates/binding-cpp.go
+++ b/internal/generator/c/templates/binding-cpp.go
@@ -39,7 +39,7 @@ const
 const obx::RelationStandalone<{{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}, {{$relation.Target.Meta.CppNamespacePrefix}}{{$relation.Target.Meta.CppName}}> {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}_::{{$relation.Meta.CppName}}({{$relation.Id.GetId}});
 {{- end}}
 
-void {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}& object) {
+void {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}::_OBX_MetaInfo::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}& object) {
 	fbb.Clear();
 	{{- range $property := $entity.Properties}}{{$factory := $property.Meta.FbOffsetFactory}}{{if $factory}}
 	auto offset{{$property.Meta.CppName}} = fbb.{{$factory}}(object.{{$property.Meta.CppName}});
@@ -56,19 +56,19 @@ void {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}_::toFlatBuffer(
 	fbb.Finish(offset);
 }
 
-{{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}} {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}_::fromFlatBuffer(const void* data, size_t size) {
+{{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}} {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t size) {
 	{{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}} object;
 	fromFlatBuffer(data, size, object);
 	return object;
 }
 
-std::unique_ptr<{{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}> {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}_::newFromFlatBuffer(const void* data, size_t size) {
+std::unique_ptr<{{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}> {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}::_OBX_MetaInfo::newFromFlatBuffer(const void* data, size_t size) {
 	auto object = std::unique_ptr<{{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}>(new {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}());
 	fromFlatBuffer(data, size, *object);
 	return object;
 }
 
-void {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}_::fromFlatBuffer(const void* data, size_t, {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}& outObject) {
+void {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t, {{$entity.Meta.CppNamespacePrefix}}{{$entity.Meta.CppName}}& outObject) {
 	const auto* table = flatbuffers::GetRoot<flatbuffers::Table>(data);
 	assert(table);
 	{{range $property := $entity.Properties}}

--- a/internal/generator/c/templates/binding-hpp.go
+++ b/internal/generator/c/templates/binding-hpp.go
@@ -42,10 +42,27 @@ var CppBindingTemplateHeader = template.Must(template.New("binding-hpp").Funcs(f
 struct {{$entity.Meta.CppName}}_;
 
 {{PrintComments 0 $entity.Comments}}struct {{$entity.Meta.CppName}} {
-    using _OBX_MetaInfo = {{$entity.Meta.CppName}}_;
-	{{range $property := $entity.Properties}}
+	{{- range $property := $entity.Properties}}
 	{{PrintComments 1 $property.Comments}}{{$property.Meta.CppType}} {{$property.Meta.CppName}};
 	{{- end}}
+
+    struct _OBX_MetaInfo {
+		static constexpr obx_schema_id entityId() { return {{$entity.Id.GetId}}; }
+	
+		static void setObjectId({{$entity.Meta.CppName}}& object, obx_id newId) { object.{{$entity.IdProperty.Meta.CppName}} = newId; }
+	
+		/// Write given object to the FlatBufferBuilder
+		static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const {{$entity.Meta.CppName}}& object);
+	
+		/// Read an object from a valid FlatBuffer
+		static {{$entity.Meta.CppName}} fromFlatBuffer(const void* data, size_t size);
+	
+		/// Read an object from a valid FlatBuffer
+		static std::unique_ptr<{{$entity.Meta.CppName}}> newFromFlatBuffer(const void* data, size_t size);
+	
+		/// Read an object from a valid FlatBuffer
+		static void fromFlatBuffer(const void* data, size_t size, {{$entity.Meta.CppName}}& outObject);
+	};
 };
 
 struct {{$entity.Meta.CppName}}_ {
@@ -58,22 +75,6 @@ struct {{$entity.Meta.CppName}}_ {
 {{- range $relation := $entity.Relations}}
 	static const obx::RelationStandalone<{{$entity.Meta.CppName}}, {{$relation.Target.Meta.CppName}}> {{$relation.Meta.CppName}};
 {{- end}}
-
-    static constexpr obx_schema_id entityId() { return {{$entity.Id.GetId}}; }
-
-    static void setObjectId({{$entity.Meta.CppName}}& object, obx_id newId) { object.{{$entity.IdProperty.Meta.CppName}} = newId; }
-
-	/// Write given object to the FlatBufferBuilder
-	static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const {{$entity.Meta.CppName}}& object);
-
-	/// Read an object from a valid FlatBuffer
-	static {{$entity.Meta.CppName}} fromFlatBuffer(const void* data, size_t size);
-
-	/// Read an object from a valid FlatBuffer
-	static std::unique_ptr<{{$entity.Meta.CppName}}> newFromFlatBuffer(const void* data, size_t size);
-
-	/// Read an object from a valid FlatBuffer
-	static void fromFlatBuffer(const void* data, size_t size, {{$entity.Meta.CppName}}& outObject);
 };
 {{with $entity.Meta.CppNamespaceEnd}}{{.}}{{end -}}
 {{end}}

--- a/test/comparison/testdata/fbs/typeful/cpp/schema.obx.cpp.expected
+++ b/test/comparison/testdata/fbs/typeful/cpp/schema.obx.cpp.expected
@@ -26,7 +26,7 @@ const obx::Property<Typeful, OBXPropertyType_Float> Typeful_::float_(21);
 const obx::Property<Typeful, OBXPropertyType_Double> Typeful_::double_(22);
 const obx::RelationProperty<Typeful, ns::AnnotatedEntity> Typeful_::relId(23);
 
-void Typeful_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const Typeful& object) {
+void Typeful::_OBX_MetaInfo::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const Typeful& object) {
     fbb.Clear();
     auto offsetstring = fbb.CreateString(object.string);
     auto offsetstringvector = fbb.CreateVectorOfStrings(object.stringvector);
@@ -61,19 +61,19 @@ void Typeful_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const Typeful& 
     fbb.Finish(offset);
 }
 
-Typeful Typeful_::fromFlatBuffer(const void* data, size_t size) {
+Typeful Typeful::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t size) {
     Typeful object;
     fromFlatBuffer(data, size, object);
     return object;
 }
 
-std::unique_ptr<Typeful> Typeful_::newFromFlatBuffer(const void* data, size_t size) {
+std::unique_ptr<Typeful> Typeful::_OBX_MetaInfo::newFromFlatBuffer(const void* data, size_t size) {
     auto object = std::unique_ptr<Typeful>(new Typeful());
     fromFlatBuffer(data, size, *object);
     return object;
 }
 
-void Typeful_::fromFlatBuffer(const void* data, size_t, Typeful& outObject) {
+void Typeful::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t, Typeful& outObject) {
     const auto* table = flatbuffers::GetRoot<flatbuffers::Table>(data);
     assert(table);
     outObject.id = table->GetField<obx_id>(4, 0);
@@ -132,7 +132,7 @@ const obx::Property<ns::Annotated, OBXPropertyType_Int> ns::Annotated_::uid(9);
 const obx::RelationStandalone<ns::Annotated, Typeful> ns::Annotated_::typefuls(1);
 const obx::RelationStandalone<ns::Annotated, Typeful> ns::Annotated_::m2m(2);
 
-void ns::Annotated_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns::Annotated& object) {
+void ns::Annotated::_OBX_MetaInfo::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns::Annotated& object) {
     fbb.Clear();
     auto offsetfullName = fbb.CreateString(object.fullName);
     auto offsetunique = fbb.CreateString(object.unique);
@@ -154,19 +154,19 @@ void ns::Annotated_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns:
     fbb.Finish(offset);
 }
 
-ns::Annotated ns::Annotated_::fromFlatBuffer(const void* data, size_t size) {
+ns::Annotated ns::Annotated::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t size) {
     ns::Annotated object;
     fromFlatBuffer(data, size, object);
     return object;
 }
 
-std::unique_ptr<ns::Annotated> ns::Annotated_::newFromFlatBuffer(const void* data, size_t size) {
+std::unique_ptr<ns::Annotated> ns::Annotated::_OBX_MetaInfo::newFromFlatBuffer(const void* data, size_t size) {
     auto object = std::unique_ptr<ns::Annotated>(new ns::Annotated());
     fromFlatBuffer(data, size, *object);
     return object;
 }
 
-void ns::Annotated_::fromFlatBuffer(const void* data, size_t, ns::Annotated& outObject) {
+void ns::Annotated::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t, ns::Annotated& outObject) {
     const auto* table = flatbuffers::GetRoot<flatbuffers::Table>(data);
     assert(table);
     outObject.identifier = table->GetField<obx_id>(4, 0);
@@ -199,7 +199,7 @@ void ns::Annotated_::fromFlatBuffer(const void* data, size_t, ns::Annotated& out
 const obx::Property<ns::TSDate, OBXPropertyType_Long> ns::TSDate_::id(1);
 const obx::Property<ns::TSDate, OBXPropertyType_Date> ns::TSDate_::timestamp(2);
 
-void ns::TSDate_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns::TSDate& object) {
+void ns::TSDate::_OBX_MetaInfo::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns::TSDate& object) {
     fbb.Clear();
     flatbuffers::uoffset_t fbStart = fbb.StartTable();
     fbb.TrackField(4, fbb.PushElement<obx_id>(object.id));
@@ -209,19 +209,19 @@ void ns::TSDate_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns::TS
     fbb.Finish(offset);
 }
 
-ns::TSDate ns::TSDate_::fromFlatBuffer(const void* data, size_t size) {
+ns::TSDate ns::TSDate::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t size) {
     ns::TSDate object;
     fromFlatBuffer(data, size, object);
     return object;
 }
 
-std::unique_ptr<ns::TSDate> ns::TSDate_::newFromFlatBuffer(const void* data, size_t size) {
+std::unique_ptr<ns::TSDate> ns::TSDate::_OBX_MetaInfo::newFromFlatBuffer(const void* data, size_t size) {
     auto object = std::unique_ptr<ns::TSDate>(new ns::TSDate());
     fromFlatBuffer(data, size, *object);
     return object;
 }
 
-void ns::TSDate_::fromFlatBuffer(const void* data, size_t, ns::TSDate& outObject) {
+void ns::TSDate::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t, ns::TSDate& outObject) {
     const auto* table = flatbuffers::GetRoot<flatbuffers::Table>(data);
     assert(table);
     outObject.id = table->GetField<obx_id>(4, 0);
@@ -232,7 +232,7 @@ void ns::TSDate_::fromFlatBuffer(const void* data, size_t, ns::TSDate& outObject
 const obx::Property<ns::TSDateNano, OBXPropertyType_Long> ns::TSDateNano_::id(1);
 const obx::Property<ns::TSDateNano, OBXPropertyType_DateNano> ns::TSDateNano_::timestamp(2);
 
-void ns::TSDateNano_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns::TSDateNano& object) {
+void ns::TSDateNano::_OBX_MetaInfo::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns::TSDateNano& object) {
     fbb.Clear();
     flatbuffers::uoffset_t fbStart = fbb.StartTable();
     fbb.TrackField(4, fbb.PushElement<obx_id>(object.id));
@@ -242,19 +242,19 @@ void ns::TSDateNano_::toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const ns
     fbb.Finish(offset);
 }
 
-ns::TSDateNano ns::TSDateNano_::fromFlatBuffer(const void* data, size_t size) {
+ns::TSDateNano ns::TSDateNano::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t size) {
     ns::TSDateNano object;
     fromFlatBuffer(data, size, object);
     return object;
 }
 
-std::unique_ptr<ns::TSDateNano> ns::TSDateNano_::newFromFlatBuffer(const void* data, size_t size) {
+std::unique_ptr<ns::TSDateNano> ns::TSDateNano::_OBX_MetaInfo::newFromFlatBuffer(const void* data, size_t size) {
     auto object = std::unique_ptr<ns::TSDateNano>(new ns::TSDateNano());
     fromFlatBuffer(data, size, *object);
     return object;
 }
 
-void ns::TSDateNano_::fromFlatBuffer(const void* data, size_t, ns::TSDateNano& outObject) {
+void ns::TSDateNano::_OBX_MetaInfo::fromFlatBuffer(const void* data, size_t, ns::TSDateNano& outObject) {
     const auto* table = flatbuffers::GetRoot<flatbuffers::Table>(data);
     assert(table);
     outObject.id = table->GetField<obx_id>(4, 0);

--- a/test/comparison/testdata/fbs/typeful/cpp/schema.obx.hpp.expected
+++ b/test/comparison/testdata/fbs/typeful/cpp/schema.obx.hpp.expected
@@ -16,8 +16,6 @@ struct Typeful_;
 /// Entity documentation is copied
 /// into the generated output
 struct Typeful {
-    using _OBX_MetaInfo = Typeful_;
-    
     obx_id id;
     int32_t int_;
     int8_t int8;
@@ -42,6 +40,24 @@ struct Typeful {
     double double_;
     /// Relation to an entity declared later in the same file
     obx_id relId;
+
+    struct _OBX_MetaInfo {
+        static constexpr obx_schema_id entityId() { return 1; }
+    
+        static void setObjectId(Typeful& object, obx_id newId) { object.id = newId; }
+    
+        /// Write given object to the FlatBufferBuilder
+        static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const Typeful& object);
+    
+        /// Read an object from a valid FlatBuffer
+        static Typeful fromFlatBuffer(const void* data, size_t size);
+    
+        /// Read an object from a valid FlatBuffer
+        static std::unique_ptr<Typeful> newFromFlatBuffer(const void* data, size_t size);
+    
+        /// Read an object from a valid FlatBuffer
+        static void fromFlatBuffer(const void* data, size_t size, Typeful& outObject);
+    };
 };
 
 struct Typeful_ {
@@ -68,22 +84,6 @@ struct Typeful_ {
     static const obx::Property<Typeful, OBXPropertyType_Float> float_;
     static const obx::Property<Typeful, OBXPropertyType_Double> double_;
     static const obx::RelationProperty<Typeful, ns::AnnotatedEntity> relId;
-
-    static constexpr obx_schema_id entityId() { return 1; }
-
-    static void setObjectId(Typeful& object, obx_id newId) { object.id = newId; }
-
-    /// Write given object to the FlatBufferBuilder
-    static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const Typeful& object);
-
-    /// Read an object from a valid FlatBuffer
-    static Typeful fromFlatBuffer(const void* data, size_t size);
-
-    /// Read an object from a valid FlatBuffer
-    static std::unique_ptr<Typeful> newFromFlatBuffer(const void* data, size_t size);
-
-    /// Read an object from a valid FlatBuffer
-    static void fromFlatBuffer(const void* data, size_t size, Typeful& outObject);
 };
 
 struct Typeful; 
@@ -92,8 +92,6 @@ namespace ns {
 struct Annotated_;
 
 struct Annotated {
-    using _OBX_MetaInfo = Annotated_;
-    
     /// Objectbox requires an ID property.
     /// It is recognized automatically if it has a right name ("id") or needs to be annotated otherwise.
     obx_id identifier;
@@ -107,6 +105,24 @@ struct Annotated {
     std::string uniqueHash64;
     /// unique on string without index type implies HASH index
     int32_t uid;
+
+    struct _OBX_MetaInfo {
+        static constexpr obx_schema_id entityId() { return 2; }
+    
+        static void setObjectId(Annotated& object, obx_id newId) { object.identifier = newId; }
+    
+        /// Write given object to the FlatBufferBuilder
+        static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const Annotated& object);
+    
+        /// Read an object from a valid FlatBuffer
+        static Annotated fromFlatBuffer(const void* data, size_t size);
+    
+        /// Read an object from a valid FlatBuffer
+        static std::unique_ptr<Annotated> newFromFlatBuffer(const void* data, size_t size);
+    
+        /// Read an object from a valid FlatBuffer
+        static void fromFlatBuffer(const void* data, size_t size, Annotated& outObject);
+    };
 };
 
 struct Annotated_ {
@@ -121,22 +137,6 @@ struct Annotated_ {
     static const obx::Property<Annotated, OBXPropertyType_Int> uid;
     static const obx::RelationStandalone<Annotated, Typeful> typefuls;
     static const obx::RelationStandalone<Annotated, Typeful> m2m;
-
-    static constexpr obx_schema_id entityId() { return 2; }
-
-    static void setObjectId(Annotated& object, obx_id newId) { object.identifier = newId; }
-
-    /// Write given object to the FlatBufferBuilder
-    static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const Annotated& object);
-
-    /// Read an object from a valid FlatBuffer
-    static Annotated fromFlatBuffer(const void* data, size_t size);
-
-    /// Read an object from a valid FlatBuffer
-    static std::unique_ptr<Annotated> newFromFlatBuffer(const void* data, size_t size);
-
-    /// Read an object from a valid FlatBuffer
-    static void fromFlatBuffer(const void* data, size_t size, Annotated& outObject);
 };
 }  // namespace ns
 
@@ -145,31 +145,31 @@ namespace ns {
 struct TSDate_;
 
 struct TSDate {
-    using _OBX_MetaInfo = TSDate_;
-    
     obx_id id;
     int64_t timestamp;
+
+    struct _OBX_MetaInfo {
+        static constexpr obx_schema_id entityId() { return 3; }
+    
+        static void setObjectId(TSDate& object, obx_id newId) { object.id = newId; }
+    
+        /// Write given object to the FlatBufferBuilder
+        static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const TSDate& object);
+    
+        /// Read an object from a valid FlatBuffer
+        static TSDate fromFlatBuffer(const void* data, size_t size);
+    
+        /// Read an object from a valid FlatBuffer
+        static std::unique_ptr<TSDate> newFromFlatBuffer(const void* data, size_t size);
+    
+        /// Read an object from a valid FlatBuffer
+        static void fromFlatBuffer(const void* data, size_t size, TSDate& outObject);
+    };
 };
 
 struct TSDate_ {
     static const obx::Property<TSDate, OBXPropertyType_Long> id;
     static const obx::Property<TSDate, OBXPropertyType_Date> timestamp;
-
-    static constexpr obx_schema_id entityId() { return 3; }
-
-    static void setObjectId(TSDate& object, obx_id newId) { object.id = newId; }
-
-    /// Write given object to the FlatBufferBuilder
-    static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const TSDate& object);
-
-    /// Read an object from a valid FlatBuffer
-    static TSDate fromFlatBuffer(const void* data, size_t size);
-
-    /// Read an object from a valid FlatBuffer
-    static std::unique_ptr<TSDate> newFromFlatBuffer(const void* data, size_t size);
-
-    /// Read an object from a valid FlatBuffer
-    static void fromFlatBuffer(const void* data, size_t size, TSDate& outObject);
 };
 }  // namespace ns
 
@@ -178,31 +178,31 @@ namespace ns {
 struct TSDateNano_;
 
 struct TSDateNano {
-    using _OBX_MetaInfo = TSDateNano_;
-    
     obx_id id;
     int64_t timestamp;
+
+    struct _OBX_MetaInfo {
+        static constexpr obx_schema_id entityId() { return 4; }
+    
+        static void setObjectId(TSDateNano& object, obx_id newId) { object.id = newId; }
+    
+        /// Write given object to the FlatBufferBuilder
+        static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const TSDateNano& object);
+    
+        /// Read an object from a valid FlatBuffer
+        static TSDateNano fromFlatBuffer(const void* data, size_t size);
+    
+        /// Read an object from a valid FlatBuffer
+        static std::unique_ptr<TSDateNano> newFromFlatBuffer(const void* data, size_t size);
+    
+        /// Read an object from a valid FlatBuffer
+        static void fromFlatBuffer(const void* data, size_t size, TSDateNano& outObject);
+    };
 };
 
 struct TSDateNano_ {
     static const obx::Property<TSDateNano, OBXPropertyType_Long> id;
     static const obx::Property<TSDateNano, OBXPropertyType_DateNano> timestamp;
-
-    static constexpr obx_schema_id entityId() { return 4; }
-
-    static void setObjectId(TSDateNano& object, obx_id newId) { object.id = newId; }
-
-    /// Write given object to the FlatBufferBuilder
-    static void toFlatBuffer(flatbuffers::FlatBufferBuilder& fbb, const TSDateNano& object);
-
-    /// Read an object from a valid FlatBuffer
-    static TSDateNano fromFlatBuffer(const void* data, size_t size);
-
-    /// Read an object from a valid FlatBuffer
-    static std::unique_ptr<TSDateNano> newFromFlatBuffer(const void* data, size_t size);
-
-    /// Read an object from a valid FlatBuffer
-    static void fromFlatBuffer(const void* data, size_t size, TSDateNano& outObject);
 };
 }  // namespace ns
 


### PR DESCRIPTION
Closes #5 

we don't actually need another struct/class, just use the already defined symbol (alias) `EntityType::_OBX_MetaInfo`