### PR TITLE
Support relative `include` directives in .fbs

### DIFF
--- a/test/integration/include-paths/cpp/main.cpp
+++ b/test/integration/include-paths/cpp/main.cpp
@@ -1,0 +1,9 @@
+#define CATCH_CONFIG_MAIN
+
+#include "catch2/catch.hpp"
+#include "objectbox.hpp"
+#include "objectbox-model.h"
+#include "schema.obx.hpp"
+#include "shared/store-init.h"
+
+using namespace obx;

--- a/test/integration/include-paths/integration_test.go
+++ b/test/integration/include-paths/integration_test.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2020 ObjectBox Ltd. All rights reserved.
+ * https://objectbox.io
+ *
+ * This file is part of ObjectBox Generator.
+ *
+ * ObjectBox Generator is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * ObjectBox Generator is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with ObjectBox Generator.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package typeful
+
+import (
+	"testing"
+
+	"github.com/objectbox/objectbox-generator/test/integration"
+)
+
+func TestCpp(t *testing.T) {
+	conf := &integration.CCppTestConf{
+		SchemaPath: "schema/schema.fbs",
+	}
+	defer conf.Cleanup()
+	conf.CommonExecute(t, integration.Cpp11)
+}

--- a/test/integration/include-paths/schema/other/other.fbs
+++ b/test/integration/include-paths/schema/other/other.fbs
@@ -1,0 +1,1 @@
+enum Values : uint { a, b }

--- a/test/integration/include-paths/schema/schema.fbs
+++ b/test/integration/include-paths/schema/schema.fbs
@@ -1,0 +1,3 @@
+include "other/other.fbs";
+
+table Entity { id: uint64; value: Values; }

--- a/test/integration/optional/integration_test.go
+++ b/test/integration/optional/integration_test.go
@@ -78,19 +78,24 @@ func TestCppAndC(t *testing.T) {
 	conf := &integration.CCppTestConf{}
 	defer conf.Cleanup()
 	conf.CreateCMake(t, integration.Cpp17, "main.cpp")
-	conf.Generate(t, map[string]string{"rel.fbs": "table RelTarget {id: uint64;}"})
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"rel.fbs": "table RelTarget {id: uint64;}"})
+	conf.Generate(t)
 
 	conf.Generator = &cgenerator.CGenerator{Optional: "std::optional"}
-	conf.Generate(t, map[string]string{"std-optional.fbs": "table Optional {" + optionalSchemaFields + "}"})
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"std-optional.fbs": "table Optional {" + optionalSchemaFields + "}"})
+	conf.Generate(t)
 
 	conf.Generator = &cgenerator.CGenerator{Optional: "std::unique_ptr"}
-	conf.Generate(t, map[string]string{"std-unique_ptr.fbs": "table UniquePtr {" + optionalSchemaFields + "}"})
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"std-unique_ptr.fbs": "table UniquePtr {" + optionalSchemaFields + "}"})
+	conf.Generate(t)
 
 	conf.Generator = &cgenerator.CGenerator{Optional: "std::shared_ptr"}
-	conf.Generate(t, map[string]string{"std-shared_ptr.fbs": "table SharedPtr {" + optionalSchemaFields + "}"})
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"std-shared_ptr.fbs": "table SharedPtr {" + optionalSchemaFields + "}"})
+	conf.Generate(t)
 
 	conf.Generator = &cgenerator.CGenerator{PlainC: true, Optional: "ptr"}
-	conf.Generate(t, map[string]string{"c-ptr.fbs": "table PlainCPtr {" + optionalSchemaFields + "}"})
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"c-ptr.fbs": "table PlainCPtr {" + optionalSchemaFields + "}"})
+	conf.Generate(t)
 
 	conf.Build(t)
 	conf.Run(t, nil)

--- a/test/integration/property-clear/property_clear_test.go
+++ b/test/integration/property-clear/property_clear_test.go
@@ -44,10 +44,8 @@ func TestCpp(t *testing.T) {
 
 	// BEFORE start
 	conf.CreateCMake(t, integration.Cpp11, "step-1.cpp")
-	conf.Generate(t, map[string]string{"schema.fbs": `table EntityName {
-	id:uint64;
-	value:int;
-}`})
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"schema.fbs": `table EntityName { id:uint64; value:int; }`})
+	conf.Generate(t)
 	modelJSONFile := generator.ModelInfoFile(conf.Cmake.ConfDir)
 	modelInfo, err := model.LoadModelFromJSONFile(modelJSONFile)
 	assert.NoErr(t, err)
@@ -69,11 +67,12 @@ func TestCpp(t *testing.T) {
 		modelInfo.Entities[0].Properties[1].Name, modelInfo.Entities[0].Properties[1].Id, newUid)
 	assert.NoErr(t, err)
 	conf.CreateCMake(t, integration.Cpp11, "step-2.cpp")
-	conf.Generate(t, map[string]string{"schema.fbs": `table EntityName {
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"schema.fbs": `table EntityName {
 	id:uint64;
 ` + "/// objectbox: uid=" + strconv.FormatInt(int64(newUid), 10) + `
 	value:int;
 }`})
+	conf.Generate(t)
 	modelInfo, err = model.LoadModelFromJSONFile(modelJSONFile)
 	assert.NoErr(t, err)
 	assert.Eq(t, 1, len(modelInfo.Entities))

--- a/test/integration/removes/remove_test.go
+++ b/test/integration/removes/remove_test.go
@@ -47,7 +47,7 @@ func TestCpp(t *testing.T) {
 
 	// STEP-1 start
 	conf.CreateCMake(t, integration.Cpp11, "step-1.cpp")
-	conf.Generate(t, map[string]string{"": "", "schema.fbs": `
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"": "", "schema.fbs": `
 /// This entity will be removed in step 2
 /// objectbox:relation(to=EntityB,name=standaloneRel)
 table EntityA {
@@ -64,6 +64,7 @@ table EntityB {
 	id:uint64;
 	name:string;
 }`})
+	conf.Generate(t)
 	modelJSONFile := generator.ModelInfoFile(conf.Cmake.ConfDir)
 	modelInfo, err := model.LoadModelFromJSONFile(modelJSONFile)
 	assert.NoErr(t, err)
@@ -97,11 +98,12 @@ table EntityB {
 
 	// STEP-2 start
 	conf.CreateCMake(t, integration.Cpp11, "step-2.cpp")
-	conf.Generate(t, map[string]string{"": "", "schema.fbs": `
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"": "", "schema.fbs": `
 table EntityB {
 	id:uint64;
 	name:string;
 }`})
+	conf.Generate(t)
 	modelInfo, err = model.LoadModelFromJSONFile(modelJSONFile)
 	assert.NoErr(t, err)
 	assert.Eq(t, 1, len(modelInfo.Entities))

--- a/test/integration/renames/rename_test.go
+++ b/test/integration/renames/rename_test.go
@@ -48,10 +48,11 @@ func TestCpp(t *testing.T) {
 
 	// BEFORE RENAME start
 	conf.CreateCMake(t, integration.Cpp11, "step-1.cpp")
-	conf.Generate(t, map[string]string{"schema.fbs": `table OldEntityName {
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"schema.fbs": `table OldEntityName {
 	id:uint64;
 	oldPropertyName:int;
 }`})
+	conf.Generate(t)
 	modelJSONFile := generator.ModelInfoFile(conf.Cmake.ConfDir)
 	modelInfo, err := model.LoadModelFromJSONFile(modelJSONFile)
 	assert.NoErr(t, err)
@@ -66,12 +67,13 @@ func TestCpp(t *testing.T) {
 
 	// AFTER RENAME start
 	conf.CreateCMake(t, integration.Cpp11, "step-2.cpp")
-	conf.Generate(t, map[string]string{"schema.fbs": "/// objectbox: uid=" + entityUid + `
+	conf.SchemaPath = conf.WriteSchemas(t, map[string]string{"schema.fbs": "/// objectbox: uid=" + entityUid + `
 table NewEntityName {
 	id:uint64;
 ` + "/// objectbox: uid=" + propertyUid + `
 	newPropertyName:int;
 }`})
+	conf.Generate(t)
 	modelInfo, err = model.LoadModelFromJSONFile(modelJSONFile)
 	assert.NoErr(t, err)
 	assert.Eq(t, 1, len(modelInfo.Entities))

--- a/third_party/flatbuffers-c-bridge/src/flatbuffersc.cpp
+++ b/third_party/flatbuffers-c-bridge/src/flatbuffersc.cpp
@@ -44,8 +44,12 @@ FBS_bytes* fbs_schema_parse_file(const char* filename, const char** out_error) {
         options.binary_schema_comments = true;  // include doc comments in the binary schema
 
         flatbuffers::Parser parser(options);
-        if (!parser.Parse(contents.c_str(), nullptr, filename)) {
+        {
+          std::string fileDir = flatbuffers::StripFileName(filename);
+          std::vector<const char *> includeDirs = {fileDir.c_str(), nullptr};
+          if (!parser.Parse(contents.c_str(), includeDirs.data(), filename)) {
             throw std::runtime_error(parser.error_);
+          }
         }
 
         if (!parser.error_.empty()) {


### PR DESCRIPTION
closes #36 

the important change is in the `flatbuffersc.cpp` - the remainder is just (for) tests